### PR TITLE
Fix crates.io badge to point to clock-bound-c

### DIFF
--- a/clock-bound-c/README.md
+++ b/clock-bound-c/README.md
@@ -1,4 +1,4 @@
-[![Crates.io](https://img.shields.io/crates/v/clock-bound-d.svg)](https://crates.io/crates/clock-bound-d)
+[![Crates.io](https://img.shields.io/crates/v/clock-bound-c.svg)](https://crates.io/crates/clock-bound-c)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # ClockBoundC

--- a/clock-bound-c/README.tpl
+++ b/clock-bound-c/README.tpl
@@ -1,4 +1,4 @@
-[![Crates.io](https://img.shields.io/crates/v/clock-bound-d.svg)](https://crates.io/crates/clock-bound-d)
+[![Crates.io](https://img.shields.io/crates/v/clock-bound-c.svg)](https://crates.io/crates/clock-bound-c)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # ClockBoundC


### PR DESCRIPTION
*Description of changes:*

Updates the crates.io badge of clock-bound-c to point to clock-bound-c instead of clock-bound-d.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
