### PR TITLE
Add support for PHC error bound interface

### DIFF
--- a/clock-bound-d/Cargo.lock
+++ b/clock-bound-d/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "clock-bound-d"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "byteorder",
  "chrono",

--- a/clock-bound-d/Cargo.toml
+++ b/clock-bound-d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock-bound-d"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Jacob Wisniewski <wisnjaco@amazon.com>"]
 description = "A daemon to provide clients with an error bounded timestamp interval."
 edition = "2021"

--- a/clock-bound-d/src/server.rs
+++ b/clock-bound-d/src/server.rs
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: GPL-2.0-only
-use crate::response::build_response;
-use crate::socket;
+use crate::{response::build_response, socket, PhcInfo};
 use chrony_candm::reply::Tracking;
 use log::warn;
-use std::io;
+use std::io::{self, Read, Error, ErrorKind};
 use tokio::sync::watch::Receiver;
 use uds::UnixDatagramExt;
+use log::error;
 
 /// The Unix Datagram Socket file for ClockBoundD
 pub const CLOCKBOUND_SERVER_SOCKET: &str = "clockboundd.sock";
@@ -16,6 +16,9 @@ pub const CLOCKBOUND_SERVER_SOCKET: &str = "clockboundd.sock";
 pub struct ClockBoundServer {
     socket: std::os::unix::net::UnixDatagram,
     tracking: Tracking,
+    phc_error_bound_path: Option<std::path::PathBuf>,
+    phc_refid: Option<u32>,
+    phc_error_bound: f64,
 }
 
 impl ClockBoundServer {
@@ -25,19 +28,82 @@ impl ClockBoundServer {
     /// # Arguments
     ///
     /// * `tracking` - The tracking information received from Chrony.
-    pub fn new(tracking: Tracking) -> ClockBoundServer {
+    /// * `phc_info` - Optional - If PHC command line args are supplied (interface and ref ID), then this PhcInfo
+    /// is used for determining the path at which to grab the PHC error bound data.
+    pub fn new(tracking: Tracking, phc_info: Option<PhcInfo>) -> Result<ClockBoundServer, io::Error> {
         let socket = socket::create_unix_socket(std::path::Path::new(CLOCKBOUND_SERVER_SOCKET));
 
-        return ClockBoundServer { socket, tracking };
+        if let Some(p) = phc_info {
+            let phc_refid = p.refid;
+            let phc_error_bound_path = match ClockBoundServer::get_error_bound_sysfs_path(p.interface) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        Error::new(
+                            ErrorKind::InvalidInput,
+                            format!("Failed to get PHC error bound sysfs path: {}", e),
+                        )
+                    );
+                }
+            };
+            let phc_error_bound = ClockBoundServer::get_phc_error_bound(&phc_error_bound_path);
+            Ok(ClockBoundServer { socket, tracking, phc_refid: Some(phc_refid), phc_error_bound_path: Some(phc_error_bound_path), phc_error_bound })
+        } else {
+            Ok(ClockBoundServer { socket, tracking,phc_refid: None, phc_error_bound_path: None, phc_error_bound: 0_f64 })
+        }
     }
 
-    /// Update Tracking data.
+    /// Gets the PHC Error Bound sysfs file path given a network interface name.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `interface` - The network interface to lookup the PHC error bound path for.
+    pub fn get_error_bound_sysfs_path(interface: String) -> Result<std::path::PathBuf, io::Error> {
+        let uevent_path = format!("/sys/class/net/{}/device/uevent", interface);
+        let mut contents = String::new();
+        std::fs::File::open(uevent_path)?.read_to_string(&mut contents)?;
+        let pci_slot_name = contents
+            .lines()
+            .find_map(|line| {
+                line.strip_prefix("PCI_SLOT_NAME=")
+            })
+            .ok_or(Error::new(
+                ErrorKind::InvalidInput,
+                format!("Failed to find PCI_SLOT_NAME for interface {}", interface),
+            ))?;
+        Ok(std::path::PathBuf::from(format!("/sys/bus/pci/devices/{}/phc_error_bound", pci_slot_name)))
+    }
+
+    /// Reads the PHC Error Bound and parses to a float.
     ///
+    /// # Arguments
+    ///
+    /// * `phc_error_bound_path` - The path of sysfs file to read PHC error bound from.
+    pub fn get_phc_error_bound(phc_error_bound_path: &std::path::Path) -> f64 {
+        let mut contents = String::new();
+        std::fs::File::open(phc_error_bound_path)
+            .expect("Could not open PHC error bound path")
+            .read_to_string(&mut contents)
+            .expect("Could not read PHC error bound file contents to str");
+        contents.trim().parse::<f64>().expect("Could not parse error bound value to f64")
+    }
+
+    /// Update Tracking data, and if we have received a new Tracking object, read PHC error bound and
+    /// update it in the server state. If the current tracking info of the ClockBoundServer indicates 
+    /// that we are not currently syncing to the PHC, or if the PHC refid and interface were not supplied,
+    /// then the phc_error_bound is set to 0.
+    /// 
     /// # Arguments
     ///
     /// * `tracking` - The tracking information received from Chrony.
     pub fn update_tracking(&mut self, tracking: Tracking) {
-        self.tracking = tracking;
+        if self.tracking != tracking {
+            self.tracking = tracking;
+            self.phc_error_bound = match (&self.phc_error_bound_path, &self.phc_refid) {
+                (Some(error_bound_path), Some(phc_refid)) if self.tracking.ref_id == *phc_refid => ClockBoundServer::get_phc_error_bound(&error_bound_path),
+                _ => 0_f64
+            }
+        }
     }
 
     /// Handle a request from a client.
@@ -72,6 +138,7 @@ impl ClockBoundServer {
             request,
             request_size,
             self.tracking,
+            self.phc_error_bound,
             error_flag,
             max_clock_error,
         );

--- a/clock-bound-d/src/tracking.rs
+++ b/clock-bound-d/src/tracking.rs
@@ -11,8 +11,7 @@ use std::io::{Error, ErrorKind};
 #[cfg(test)]
 use std::net::IpAddr;
 use std::time::SystemTime;
-
-const NANOSEC_IN_SEC: u32 = 1_000_000_000;
+use crate::NANOSEC_IN_SEC;
 
 /// Compute current root dispersion.
 ///


### PR DESCRIPTION
With EC2 introducing a PTP Hardware Clock on instances, Chrony under-reports the clock error bound, assuming that it is 0 when that is not the case. The ENA driver exposes an interface for gathering the clock error bound of the PTP Hardware Clock (PHC) itself. We need to add this interface's error bound value to the clock error bound reported from ClockBound so that we do not underestimate our clock error.

This commit adds support for users to supply a PHC reference ID (this comes from chronyd, generally will be PHC0) and and a PHC interface (the network interface for ENA driver where PHC is exposed). If supplied both of these arguments, Clockbound will, whenever it polls Chrony for error bound information, add the PHC error bound to its own error bound reported if Chrony is syncing to the PHC (otherwise 0).

*Issue #, if available:*
N/A

*Description of changes:*
Adds support for 2 new args, --phc-ref-id and --phc-interface which both require each other - these are used to determine the path at which to access PHC error bound interface from the ENA driver. When these are supplied, PHC error bound will be added to chrony clock error bound.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
