### PR TITLE
Update CHANGELOG with 0.1.4 changes

### DIFF
--- a/clock-bound-d/CHANGELOG.md
+++ b/clock-bound-d/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2023-11-16
+### Added
+- ClockBound now supports [reading error bound from a PHC device](https://github.com/amzn/amzn-drivers/tree/master/kernel/linux/ena) as exposed from ENA driver
+- Bump tokio dependency from 1.18.4 to 1.18.5
+
 ## [0.1.3] - 2023-01-11
 ### Added
 - Bump tokio dependency from 1.17.0 to 1.18.4


### PR DESCRIPTION
Version was bumped in Cargo.toml when enabling PHC, but CHANGELOG didn't have those changes mentioned - adding them now.

*Issue #, if available:*
N/A

*Description of changes:*
PHC enablement is now described in CHANGELOG


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
