### PR TITLE
Update PHC error bound feature failure cases

### DIFF
--- a/clock-bound-d/src/server.rs
+++ b/clock-bound-d/src/server.rs
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 use crate::{response::build_response, socket, PhcInfo};
 use chrony_candm::reply::Tracking;
-use log::warn;
-use std::io::{self, Read, Error, ErrorKind};
+use log::{error, warn};
+use std::io;
 use tokio::sync::watch::Receiver;
 use uds::UnixDatagramExt;
-use log::error;
 
 /// The Unix Datagram Socket file for ClockBoundD
 pub const CLOCKBOUND_SERVER_SOCKET: &str = "clockboundd.sock";
@@ -16,8 +15,7 @@ pub const CLOCKBOUND_SERVER_SOCKET: &str = "clockboundd.sock";
 pub struct ClockBoundServer {
     socket: std::os::unix::net::UnixDatagram,
     tracking: Tracking,
-    phc_error_bound_path: Option<std::path::PathBuf>,
-    phc_refid: Option<u32>,
+    phc_info: Option<PhcInfo>,
     phc_error_bound: f64,
 }
 
@@ -30,48 +28,14 @@ impl ClockBoundServer {
     /// * `tracking` - The tracking information received from Chrony.
     /// * `phc_info` - Optional - If PHC command line args are supplied (interface and ref ID), then this PhcInfo
     /// is used for determining the path at which to grab the PHC error bound data.
-    pub fn new(tracking: Tracking, phc_info: Option<PhcInfo>) -> Result<ClockBoundServer, io::Error> {
+    pub fn new(tracking: Tracking, phc_info: Option<PhcInfo>) -> ClockBoundServer {
         let socket = socket::create_unix_socket(std::path::Path::new(CLOCKBOUND_SERVER_SOCKET));
-
-        if let Some(p) = phc_info {
-            let phc_refid = p.refid;
-            let phc_error_bound_path = match ClockBoundServer::get_error_bound_sysfs_path(p.interface) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        Error::new(
-                            ErrorKind::InvalidInput,
-                            format!("Failed to get PHC error bound sysfs path: {}", e),
-                        )
-                    );
-                }
-            };
-            let phc_error_bound = ClockBoundServer::get_phc_error_bound(&phc_error_bound_path);
-            Ok(ClockBoundServer { socket, tracking, phc_refid: Some(phc_refid), phc_error_bound_path: Some(phc_error_bound_path), phc_error_bound })
-        } else {
-            Ok(ClockBoundServer { socket, tracking,phc_refid: None, phc_error_bound_path: None, phc_error_bound: 0_f64 })
+        ClockBoundServer {
+            socket,
+            tracking,
+            phc_info,
+            phc_error_bound: 0_f64,
         }
-    }
-
-    /// Gets the PHC Error Bound sysfs file path given a network interface name.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `interface` - The network interface to lookup the PHC error bound path for.
-    pub fn get_error_bound_sysfs_path(interface: String) -> Result<std::path::PathBuf, io::Error> {
-        let uevent_path = format!("/sys/class/net/{}/device/uevent", interface);
-        let mut contents = String::new();
-        std::fs::File::open(uevent_path)?.read_to_string(&mut contents)?;
-        let pci_slot_name = contents
-            .lines()
-            .find_map(|line| {
-                line.strip_prefix("PCI_SLOT_NAME=")
-            })
-            .ok_or(Error::new(
-                ErrorKind::InvalidInput,
-                format!("Failed to find PCI_SLOT_NAME for interface {}", interface),
-            ))?;
-        Ok(std::path::PathBuf::from(format!("/sys/bus/pci/devices/{}/phc_error_bound", pci_slot_name)))
     }
 
     /// Reads the PHC Error Bound and parses to a float.
@@ -79,29 +43,41 @@ impl ClockBoundServer {
     /// # Arguments
     ///
     /// * `phc_error_bound_path` - The path of sysfs file to read PHC error bound from.
-    pub fn get_phc_error_bound(phc_error_bound_path: &std::path::Path) -> f64 {
-        let mut contents = String::new();
-        std::fs::File::open(phc_error_bound_path)
-            .expect("Could not open PHC error bound path")
-            .read_to_string(&mut contents)
-            .expect("Could not read PHC error bound file contents to str");
-        contents.trim().parse::<f64>().expect("Could not parse error bound value to f64")
+    pub fn get_phc_error_bound(
+        phc_error_bound_path: &std::path::Path,
+    ) -> Result<f64, std::io::Error> {
+        Ok(std::fs::read_to_string(phc_error_bound_path)?
+            .trim()
+            .parse::<f64>()
+            .expect("Could not parse error bound value to f64"))
     }
 
     /// Update Tracking data, and if we have received a new Tracking object, read PHC error bound and
-    /// update it in the server state. If the current tracking info of the ClockBoundServer indicates 
+    /// update it in the server state. If the current tracking info of the ClockBoundServer indicates
     /// that we are not currently syncing to the PHC, or if the PHC refid and interface were not supplied,
     /// then the phc_error_bound is set to 0.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `tracking` - The tracking information received from Chrony.
     pub fn update_tracking(&mut self, tracking: Tracking) {
         if self.tracking != tracking {
-            self.tracking = tracking;
-            self.phc_error_bound = match (&self.phc_error_bound_path, &self.phc_refid) {
-                (Some(error_bound_path), Some(phc_refid)) if self.tracking.ref_id == *phc_refid => ClockBoundServer::get_phc_error_bound(&error_bound_path),
-                _ => 0_f64
+            match &self.phc_info {
+                // If syncing to PHC, set PHC error bound too if possible.
+                Some(phc_info) if phc_info.refid == tracking.ref_id => {
+                    match ClockBoundServer::get_phc_error_bound(&phc_info.sysfs_error_bound_path) {
+                        Ok(phc_error_bound) => {
+                            self.phc_error_bound = phc_error_bound;
+                            self.tracking = tracking;
+                        }
+                        Err(e) => error!("Failed to retrieve PHC error bound when Chrony was tracking PHC, error bound will not be updated: {:?}", e)
+                    }
+                }
+                // If not syncing to PHC, PHC error bound should not be added in.
+                _ => {
+                    self.tracking = tracking;
+                    self.phc_error_bound = 0_f64;
+                }
             }
         }
     }


### PR DESCRIPTION
In our first iteration of support for PHC error bound interface in ClockBound, we made it possible to panic upon failure to read the PHC error bound sysfs file, which could cause unexpected crashes in the ClockBound daemon. Now, we handle such errors when reading the sysfs file.

Additionally, we migrate some of the initialization logic for discovering the path of the sysfs error bound file into the main entry point instead and allow PhcInfo to hold that path instead of the interface used to discover that path. To have finer grained control over the output in stderr when `main` runs into an Err case, we also change typing to use a String instead of printing std::io::Error contents.

*Issue #, if available:*
N/A

*Description of changes:*

See commit message for more details - this updates PHC error bound logic to reduce potential panic paths and moves logic out of ClockBoundServer for retrieving PHC error bound path, instead putting this into the `main` routine's early initialization.

Notably, this also changes the `main` routine's return to `Result<(), String>` to give us more tight grained control over what's printed to stderr in failure modes rather than std::io:Error contents.

*Testing:*
Threw this onto an instance supporting PHC error bound interface and used a python script to extract clockbound's reported error bound, chrony's reported error bound, and the PHC error bound as well, and values look within sane range (with dispersion within clockbound causing the delta here). `ceb_tracking` is Clock Error Bound calculated in Chrony, `clockbound_error_bound` is the error bound (latest - earliest) / 2, and the latter line is us reading the sysfs error bound directly.
```
[ec2-user@ip-10-0-190-225 ~]$ sudo python3 test.py && cat /sys/bus/pci/devices/0000\:00\:05.0/phc_error_bound 
{'rootDelay_ntpData': 1.5e-05, 'rootDispersion_ntpData': 1.5e-05, 'refTime_ntpData': 1705424952.0914304, 'offset_ntpData': -5.72e-06, 'peerDelay_ntpData': 0.000100284, 'peerDispersion_ntpData': 3.845e-06, 'offset_tracking': 4e-09, 'rootDelay_tracking': 1e-05, 'rootDispersion_tracking': 8.81e-07, 'refTime_tracking': 1705424965.643161, 'ceb_tracking': 5885.0, 'clockbound_error_bound': 23516.0}
15235
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
