### PR TITLE
ClockBound version 2.0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ exclude = []
 keywords = ["aws", "ntp", "ec2", "time"]
 publish = true
 repository = "https://github.com/aws/clock-bound"
-version = "2.0.1"
+version = "2.0.2"

--- a/clock-bound-client/CHANGELOG.md
+++ b/clock-bound-client/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2025-07-30
+
+### Removed
+
+- In dependency 'clock-bound-vmclock', the Cargo.toml no longer specifies
+  logging level filter features for the 'tracing' crate.
+
 ## [2.0.1] - 2025-05-26
 
 ## [2.0.0] - 2025-04-21

--- a/clock-bound-d/CHANGELOG.md
+++ b/clock-bound-d/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2025-07-30
+
 ## [2.0.1] - 2025-05-26
 
 ### Changed

--- a/clock-bound-vmclock/Cargo.toml
+++ b/clock-bound-vmclock/Cargo.toml
@@ -21,7 +21,7 @@ byteorder = "1"
 errno = { version = "0.3.0", default-features = false }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 nix = { version = "0.26", features = ["feature", "time"] }
-tracing = { version = "0.1", features = ["max_level_debug", "release_max_level_info"]}
+tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "json"] }
 
 [dev-dependencies]


### PR DESCRIPTION
ClockBound version 2.0.2.

List of changes:

- Remove tracing level filter feature from client library crates.

--- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
